### PR TITLE
Allow users to specify a build platform

### DIFF
--- a/docker/build.sh
+++ b/docker/build.sh
@@ -1,25 +1,37 @@
+PLATFORM=${1:-all}
+
 # Make sure all containers are build and up to date
-./docker/prepare.sh
+./docker/prepare.sh $PLATFORM
 
 # Clean previous build output
 rm -rf ./output/*/
 
-# Build Debian x86_64
-mkdir -p ./output/debian/x86_64
-docker run --mount src="$(pwd)/output/debian/x86_64",target=/q2pro/output,type=bind -it q2pro-cc-debian-x86_64 /usr/bin/make
+if [ $PLATFORM = debian64 ] || [ $PLATFORM = all ] ; then
+    # Build Debian x86_64
+    mkdir -p ./output/debian/x86_64
+    docker run --mount src="$(pwd)/output/debian/x86_64",target=/q2pro/output,type=bind -it q2pro-cc-debian-x86_64 //usr/bin/make
+fi
 
-# Build Ubuntu x86_64
-mkdir -p ./output/ubuntu/x86_64
-docker run --mount src="$(pwd)/output/ubuntu/x86_64",target=/q2pro/output,type=bind -it q2pro-cc-ubuntu-x86_64 /usr/bin/make
+if [ $PLATFORM = ubuntu64 ] || [ $PLATFORM = all ] ; then
+    # Build Ubuntu x86_64
+    mkdir -p ./output/ubuntu/x86_64
+    docker run --mount src="$(pwd)/output/ubuntu/x86_64",target=/q2pro/output,type=bind -it q2pro-cc-ubuntu-x86_64 //usr/bin/make
+fi
 
-# Build Fedora x86_64
-mkdir -p ./output/fedora/x86_64
-docker run --mount src="$(pwd)/output/fedora/x86_64",target=/q2pro/output,type=bind -it q2pro-cc-fedora-x86_64 /usr/bin/make
+if [ $PLATFORM = fedora64 ] || [ $PLATFORM = all ] ; then
+    # Build Fedora x86_64
+    mkdir -p ./output/fedora/x86_64
+    docker run --mount src="$(pwd)/output/fedora/x86_64",target=/q2pro/output,type=bind -it q2pro-cc-fedora-x86_64 //usr/bin/make
+fi
 
-# Build Windows x86_64
-mkdir -p ./output/windows/x86_64
-docker run --mount src="$(pwd)/output/windows/x86_64",target=/q2pro/output,type=bind -it q2pro-cc-windows-x86_64 /usr/bin/make
+if [ $PLATFORM = win64 ] || [ $PLATFORM = all ] ; then
+    # Build Windows x86_64
+    mkdir -p ./output/windows/x86_64
+    docker run --mount src="$(pwd)/output/windows/x86_64",target=/q2pro/output,type=bind -it q2pro-cc-windows-x86_64 //usr/bin/make
+fi
 
-# Build Darwin x86_64
-make clean CONFIG_FILE=./config_darwin
-make all CONFIG_FILE=./config_darwin
+if [ $PLATFORM = darwin64 ] || [ $PLATFORM = all ] ; then
+    # Build Darwin x86_64
+    make clean CONFIG_FILE=./config_darwin
+    make all CONFIG_FILE=./config_darwin
+fi

--- a/docker/package.sh
+++ b/docker/package.sh
@@ -1,20 +1,32 @@
+PLATFORM=${1:-all}
+
 # Make sure all builds are run
-./docker/build.sh
+./docker/build.sh $PLATFORM
 
 # Remove previous packages
 rm ./output/*.tar.gz
 
-# Package Debian x86_64
-tar -cvzf ./output/debian_x86_64.tar.gz -C ./output/debian/x86_64 . -C ../../.. ./baseq2 -C ./ ./manifest.json
+if [ $PLATFORM = debian64 ] || [ $PLATFORM = all ] ; then
+    # Package Debian x86_64
+    tar -cvzf ./output/debian_x86_64.tar.gz -C ./output/debian/x86_64 . -C ../../.. ./baseq2 -C ./ ./manifest.json
+fi
 
-# Package Ubuntu x86_64
-tar -cvzf ./output/ubuntu_x86_64.tar.gz -C ./output/ubuntu/x86_64 . -C ../../.. ./baseq2 -C ./ ./manifest.json
+if [ $PLATFORM = ubuntu64 ] || [ $PLATFORM = all ] ; then
+    # Package Ubuntu x86_64
+    tar -cvzf ./output/ubuntu_x86_64.tar.gz -C ./output/ubuntu/x86_64 . -C ../../.. ./baseq2 -C ./ ./manifest.json
+fi
 
-# Package Fedora x86_64
-tar -cvzf ./output/fedora_x86_64.tar.gz -C ./output/fedora/x86_64 . -C ../../.. ./baseq2 -C ./ ./manifest.json
+if [ $PLATFORM = fedora64 ] || [ $PLATFORM = all ] ; then
+    # Package Fedora x86_64
+    tar -cvzf ./output/fedora_x86_64.tar.gz -C ./output/fedora/x86_64 . -C ../../.. ./baseq2 -C ./ ./manifest.json
+fi
 
-# Package Windows x86_64
-tar -cvzf ./output/windows_x86_64.tar.gz -C ./output/windows/x86_64 . -C ../../.. ./baseq2 -C ./ ./manifest.json
+if [ $PLATFORM = win64 ] || [ $PLATFORM = all ] ; then
+    # Package Windows x86_64
+    tar -cvzf ./output/windows_x86_64.tar.gz -C ./output/windows/x86_64 . -C ../../.. ./baseq2 -C ./ ./manifest.json
+fi
 
-# Package Darwin x86_64
-tar -cvzf ./output/darwin_x86_64.tar.gz -C ./output/darwin/x86_64 . -C ../../.. ./baseq2 -C ./ ./manifest.json
+if [ $PLATFORM = darwin64 ] || [ $PLATFORM = all ] ; then
+    # Package Darwin x86_64
+    tar -cvzf ./output/darwin_x86_64.tar.gz -C ./output/darwin/x86_64 . -C ../../.. ./baseq2 -C ./ ./manifest.json
+fi

--- a/docker/prepare.sh
+++ b/docker/prepare.sh
@@ -1,11 +1,21 @@
-# Debian x86_64
-docker build -t q2pro-cc-debian-x86_64 -f ./docker/debian_x86_64/Dockerfile .
+PLATFORM=${1:-all}
 
-# Ubuntu x86_64
-docker build -t q2pro-cc-ubuntu-x86_64 -f ./docker/ubuntu_x86_64/Dockerfile .
+if [ $PLATFORM = debian64 ] || [ $PLATFORM = all ] ; then
+    # Debian x86_64
+    docker build -t q2pro-cc-debian-x86_64 -f ./docker/debian_x86_64/Dockerfile .
+fi
 
-# Fedora x86_64
-docker build -t q2pro-cc-fedora-x86_64 -f ./docker/fedora_x86_64/Dockerfile .
+if [ $PLATFORM = ubuntu64 ] || [ $PLATFORM = all ] ; then
+    # Ubuntu x86_64
+    docker build -t q2pro-cc-ubuntu-x86_64 -f ./docker/ubuntu_x86_64/Dockerfile .
+fi
 
-# Windows x86_64
-docker build -t q2pro-cc-windows-x86_64 -f ./docker/windows_x86_64/Dockerfile .
+if [ $PLATFORM = fedora64 ] || [ $PLATFORM = all ] ; then
+    # Fedora x86_64
+    docker build -t q2pro-cc-fedora-x86_64 -f ./docker/fedora_x86_64/Dockerfile .
+fi
+
+if [ $PLATFORM = win64 ] || [ $PLATFORM = all ] ; then
+    # Windows x86_64
+    docker build -t q2pro-cc-windows-x86_64 -f ./docker/windows_x86_64/Dockerfile .
+fi


### PR DESCRIPTION
Allows easier debugging for a single platform since you don't need to comment lines or wait until all builds finished.